### PR TITLE
Deploy Maven artifacts to Sonatype

### DIFF
--- a/dotify.api/build.gradle
+++ b/dotify.api/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "java"
 apply plugin: "maven"
 //custom plugins
 apply plugin: "bundle"
-apply plugin: 'signing'
+apply plugin: "signing"
 
 group = "org.daisy.dotify"
 version = "1.0-SNAPSHOT"
@@ -104,7 +104,7 @@ uploadArchives {
                 authentication(userName: sonatypeUsername, password: sonatypePassword)
             }
             pom.project {
-                name 'Dotify'
+                name 'Dotify - dotify.api'
                 packaging 'jar'
                 description 'Dotify braille translation system'
                 url 'https://code.google.com/p/dotify/'

--- a/dotify.api/build.gradle
+++ b/dotify.api/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "java"
 apply plugin: "maven"
 //custom plugins
 apply plugin: "bundle"
+apply plugin: 'signing'
 
 group = "org.daisy.dotify"
 version = "1.0-SNAPSHOT"
@@ -69,3 +70,60 @@ bundle {
     ]
 }
 
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+
+signing {
+    required { isReleaseVersion }
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            pom.project {
+                name 'Dotify'
+                packaging 'jar'
+                description 'Dotify braille translation system'
+                url 'https://code.google.com/p/dotify/'
+                scm {
+                    connection 'scm:git:https://github.com/mtmse/dotify.git'
+                    developerConnection 'scm:git:https://github.com/mtmse/dotify.git'
+                    url 'https://github.com/mtmse/dotify'
+                }
+                licenses {
+                    license {
+                        name 'LGPL'
+                        url 'http://www.gnu.org/licenses/lgpl.html'
+                    }
+                }
+                developers {
+                    developer {
+                        id 'joel'
+                        name 'Joel Håkansson'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dotify.api/build.gradle
+++ b/dotify.api/build.gradle
@@ -87,14 +87,16 @@ artifacts {
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 signing {
-    required { isReleaseVersion }
+    required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 
 uploadArchives {
     repositories {
         mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            if (isReleaseVersion) {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            }
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
                 authentication(userName: sonatypeUsername, password: sonatypePassword)
             }

--- a/dotify.common/build.gradle
+++ b/dotify.common/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "java"
 apply plugin: "maven"
 //custom plugins
 apply plugin: "bundle"
+apply plugin: "signing"
 
 group = "org.daisy.dotify"
 version = "1.0-SNAPSHOT"
@@ -45,3 +46,63 @@ buildscript {
 }
 
 bundle { instructions << [ "-include": file('bnd.bnd') ] }
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+
+signing {
+    required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            if (isReleaseVersion) {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            }
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            pom.project {
+                name 'Dotify - dotify.common'
+                packaging 'jar'
+                description 'Dotify braille translation system'
+                url 'https://code.google.com/p/dotify/'
+                scm {
+                    connection 'scm:git:https://github.com/mtmse/dotify.git'
+                    developerConnection 'scm:git:https://github.com/mtmse/dotify.git'
+                    url 'https://github.com/mtmse/dotify'
+                }
+                licenses {
+                    license {
+                        name 'LGPL'
+                        url 'http://www.gnu.org/licenses/lgpl.html'
+                    }
+                }
+                developers {
+                    developer {
+                        id 'joel'
+                        name 'Joel Håkansson'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dotify.formatter.impl/build.gradle
+++ b/dotify.formatter.impl/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "java"
 apply plugin: "maven"
 //custom plugins
 apply plugin: "bundle"
+apply plugin: "signing"
 
 group = "org.daisy.dotify"
 version = "1.0-SNAPSHOT"
@@ -66,4 +67,64 @@ bundle {
     instructions << [
         "-include": file('bnd.bnd'),
     ]
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+
+signing {
+    required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            if (isReleaseVersion) {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            }
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            pom.project {
+                name 'Dotify - dotify.formatter.impl'
+                packaging 'jar'
+                description 'Dotify braille translation system'
+                url 'https://code.google.com/p/dotify/'
+                scm {
+                    connection 'scm:git:https://github.com/mtmse/dotify.git'
+                    developerConnection 'scm:git:https://github.com/mtmse/dotify.git'
+                    url 'https://github.com/mtmse/dotify'
+                }
+                licenses {
+                    license {
+                        name 'LGPL'
+                        url 'http://www.gnu.org/licenses/lgpl.html'
+                    }
+                }
+                developers {
+                    developer {
+                        id 'joel'
+                        name 'Joel Håkansson'
+                    }
+                }
+            }
+        }
+    }
 }

--- a/dotify.translator.impl/build.gradle
+++ b/dotify.translator.impl/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "java"
 apply plugin: "maven"
 //custom plugins
 apply plugin: "bundle"
+apply plugin: "signing"
 
 group = "org.daisy.dotify"
 version = "1.0-SNAPSHOT"
@@ -66,4 +67,64 @@ bundle {
     instructions << [
         "-include": file('bnd.bnd')
     ]
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+
+signing {
+    required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            if (isReleaseVersion) {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            }
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+            pom.project {
+                name 'Dotify - dotify.translator.impl'
+                packaging 'jar'
+                description 'Dotify braille translation system'
+                url 'https://code.google.com/p/dotify/'
+                scm {
+                    connection 'scm:git:https://github.com/mtmse/dotify.git'
+                    developerConnection 'scm:git:https://github.com/mtmse/dotify.git'
+                    url 'https://github.com/mtmse/dotify'
+                }
+                licenses {
+                    license {
+                        name 'LGPL'
+                        url 'http://www.gnu.org/licenses/lgpl.html'
+                    }
+                }
+                developers {
+                    developer {
+                        id 'joel'
+                        name 'Joel Håkansson'
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Taken from http://central.sonatype.org/pages/gradle.html

This is how it works:

``` sh
gradle uploadArchives -Psigning.password=foo -PsonatypePassword=bar
```

You also need to have the properties `signing.keyId`, `signing.secretKeyRingFile` and `sonatypeUsername` set in your ~/.gradle/gradle.properties

To do:
- [ ] do the same for other modules
- [ ] find out how this can be done automatically with Jenkins (e.g. which signing key to use and where to store key passphrase and password for Sonatype?)
