### PR TITLE
Fix handling of xml-processor in OSGi environment

### DIFF
--- a/dotify.formatter.impl/build.gradle
+++ b/dotify.formatter.impl/build.gradle
@@ -95,7 +95,8 @@ bundle {
         'Built-By': System.getProperty("user.name"),
         'Built-On': new Date().format('yyyy-MM-dd'),
         'Repository-Revision': "$repositoryRevision",
-        'Repository-URL': "$repositoryURL"
+        'Repository-URL': "$repositoryURL",
+        'SPI-Consumer': 'javax.xml.transform.TransformerFactory#newInstance()'
     ]
 }
 


### PR DESCRIPTION
TransformerFactory.newInstance(), which is currently used to obtain a TransformerFactory object, returns a Xalan object because the method does not work well with OSGi, and the Xalan implementation fails for some reason.

Therefore as a temporary solution I added a SPI Fly header to the manifest which fixes the TransformerFactory.newInstance() method in OSGi.

A better solution would be to make it possible to somehow bind a TransformerFactory to LayoutEngineFactoryImpl through OSGi.
